### PR TITLE
Append Multi-Arch: foreign to config-package-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,7 @@ Standards-Version: 4.1.0
 Package: config-package-dev
 Architecture: all
 Depends: ${misc:Depends}, ${perl:Depends}
+Multi-Arch: foreign
 Description: Debhelper (and CDBS) modules for building configuration packages
  This package contains a system of modules for creating Debian
  configuration packages: packages that configure an existing Debian


### PR DESCRIPTION
Enables you to build packages depending on config-package-dev for foreign architectures.