### PR TITLE
Add test dependency on build-essential

### DIFF
--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,3 +1,3 @@
 Tests: examples
-Depends: @, debhelper, cdbs, dh-buildinfo, lynx
+Depends: @, build-essential, debhelper, cdbs, dh-buildinfo, lynx
 Restrictions: allow-stderr


### PR DESCRIPTION
This should fix https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1108856 once it's in a release. Time for 5.5.1?