### PR TITLE
remove dedency on obsolete & stubbed "dh-buildinfo"

### DIFF
--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,3 +1,3 @@
 Tests: examples
-Depends: @, build-essential, debhelper, cdbs, dh-buildinfo, lynx
+Depends: @, build-essential, debhelper, cdbs, lynx
 Restrictions: allow-stderr

--- a/examples/cdbs/debathena-bin-example-1.0/debian/control
+++ b/examples/cdbs/debathena-bin-example-1.0/debian/control
@@ -5,7 +5,6 @@ Maintainer: Tim Abbott <tabbott@mit.edu>
 Rules-Requires-Root: no
 Build-Depends: cdbs,
  debhelper,
- dh-buildinfo,
  config-package-dev (>= 4.5~)
 Standards-Version: 4.1.0
 

--- a/examples/cdbs/debathena-bin-example-1.1/debian/control
+++ b/examples/cdbs/debathena-bin-example-1.1/debian/control
@@ -5,7 +5,6 @@ Maintainer: Tim Abbott <tabbott@mit.edu>
 Rules-Requires-Root: no
 Build-Depends: cdbs,
  debhelper,
- dh-buildinfo,
  config-package-dev (>= 4.5~)
 Standards-Version: 4.1.0
 

--- a/examples/cdbs/debathena-conffile-example-1.0/debian/control
+++ b/examples/cdbs/debathena-conffile-example-1.0/debian/control
@@ -5,7 +5,6 @@ Maintainer: Tim Abbott <tabbott@mit.edu>
 Rules-Requires-Root: no
 Build-Depends: cdbs,
  debhelper,
- dh-buildinfo,
  config-package-dev (>= 4.5~)
 Standards-Version: 4.1.0
 

--- a/examples/cdbs/debathena-conffile-example-1.1/debian/control
+++ b/examples/cdbs/debathena-conffile-example-1.1/debian/control
@@ -5,7 +5,6 @@ Maintainer: Jonathan Reed <jdreed@mit.edu>
 Rules-Requires-Root: no
 Build-Depends: cdbs,
  debhelper,
- dh-buildinfo,
  config-package-dev (>= 4.5~)
 Standards-Version: 4.1.0
 

--- a/examples/cdbs/debathena-cron-example-1.0/debian/control
+++ b/examples/cdbs/debathena-cron-example-1.0/debian/control
@@ -5,7 +5,6 @@ Maintainer: Tim Abbott <tabbott@mit.edu>
 Rules-Requires-Root: no
 Build-Depends: cdbs,
  debhelper,
- dh-buildinfo,
  config-package-dev (>= 4.5~)
 Standards-Version: 4.1.0
 

--- a/examples/cdbs/debathena-transform-example-1.0/debian/control
+++ b/examples/cdbs/debathena-transform-example-1.0/debian/control
@@ -5,7 +5,6 @@ Maintainer: Tim Abbott <tabbott@mit.edu>
 Rules-Requires-Root: no
 Build-Depends: cdbs,
  debhelper,
- dh-buildinfo,
  config-package-dev (>= 4.5~), lynx
 Standards-Version: 4.1.0
 


### PR DESCRIPTION
Old dh-buildinfo package does not exist anymore.

This is now merely a virtual "Provides:" of debhelper that does absolutely nothing. That should go away too.